### PR TITLE
Fix starts the default app associated with the specified file in wp8.1

### DIFF
--- a/src/wp/InAppBrowser.cs
+++ b/src/wp/InAppBrowser.cs
@@ -1,15 +1,15 @@
 ﻿/*
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 */
 
 using System;
@@ -242,7 +242,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             var file = await GetFile(pathUri.AbsolutePath.Replace('/', Path.DirectorySeparatorChar));
             if (file != null)
             {
-                await Launcher.LaunchFileAsync(file);
+                Deployment.Current.Dispatcher.BeginInvoke(() => { Launcher.LaunchFileAsync(file); });
             }
             else
             {


### PR DESCRIPTION
The calling app must be visible to the user when the API is invoked.
This API must be called from an UI thread.

ping @mbektchiev @nadyaA
